### PR TITLE
[Bug fix] Non-editable fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.2'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
     }

--- a/example/src/main/java/com/dsc/formbuilder/MainActivity.kt
+++ b/example/src/main/java/com/dsc/formbuilder/MainActivity.kt
@@ -32,24 +32,13 @@ class MainActivity : ComponentActivity() {
     @Composable
     fun Content() {
         val formState: FormState<BaseState<out Any>> = remember { viewModel.formState }
-        val ageState: TextFieldState = formState.getState<TextFieldState>("age").also {
-            it.change(23.toString())
-        }
-        val emailState: TextFieldState = formState.getState<TextFieldState>("email").also {
-            it.change("example@gmail.com")
-        }
-        val passwordState: TextFieldState = formState.getState<TextFieldState>("password").also {
-            it.change("123456")
-        }
-        val genderState: ChoiceState = formState.getState<ChoiceState>("gender").also {
-            it.change("Male")
-        }
-        val happinessState: TextFieldState = formState.getState<TextFieldState>("happiness").also {
-            it.change(0.1.toString())
-        }
-        val hobbiesState: SelectState = formState.getState<SelectState>("hobbies").also {
-            it.select("Reading")
-        }
+        val ageState: TextFieldState = formState.getState("age")
+        val genderState: ChoiceState = formState.getState("gender")
+        val emailState: TextFieldState = formState.getState("email")
+        val passwordState: TextFieldState = formState.getState("password")
+        val happinessState: TextFieldState = formState.getState("happiness")
+        val hobbiesState: SelectState = formState.getState<SelectState>("hobbies")
+
         val scrollState = rememberScrollState()
 
         Column(

--- a/example/src/main/java/com/dsc/formbuilder/MainViewModel.kt
+++ b/example/src/main/java/com/dsc/formbuilder/MainViewModel.kt
@@ -18,6 +18,7 @@ class MainViewModel : ViewModel() {
             ),
             TextFieldState(
                 name = "email",
+                initial = "name@mail.com",
                 transform = { it.trim().lowercase() },
                 validators = listOf(Validators.Email()),
             ),
@@ -27,6 +28,7 @@ class MainViewModel : ViewModel() {
             ),
             TextFieldState(
                 name = "age",
+                initial = "18",
                 transform = { it.toInt() },
                 validators = listOf(Validators.MinValue(limit = 18, message = "too young"))
             ),

--- a/example/src/main/java/com/dsc/formbuilder/MainViewModel.kt
+++ b/example/src/main/java/com/dsc/formbuilder/MainViewModel.kt
@@ -13,6 +13,7 @@ class MainViewModel : ViewModel() {
     val formState = FormState(
         fields = listOf(
             ChoiceState(
+                initial = "Male",
                 name = "gender",
                 validators = listOf(Validators.Required(message = "you need to specify your gender"))
             ),
@@ -38,6 +39,7 @@ class MainViewModel : ViewModel() {
                 validators = listOf(Validators.Required(message = "how happy are you?"))
             ),
             SelectState(
+                initial = mutableListOf("Chess"),
                 name = "hobbies",
                 validators = listOf(
                     Validators.Required(message = "pick at least one hobby")

--- a/form-builder/src/main/java/com/dsc/form_builder/BaseState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/BaseState.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
  *
  * This is the abstract base state that defines the basic behaviour for all form states.
  *
+ * @param initial the initial value/state of the class.
  * @param name this is the name of the state. It is used to access the state when required in the form. It is also used when creating the class in the [getData] method of the [FormState] class.
  * @param transform this function is used to change the data type in the field state. You can use it to convert the data in the field to your preferred type e.g [String] to [Int]
  * @param validators this is the list of [Validators] that are used to validate the field state. By default most states will have an empty list. You can override this and provide your own list of validators.
@@ -16,6 +17,7 @@ import androidx.compose.runtime.setValue
  * @created 05/04/2022 - 10:00 AM
  */
 abstract class BaseState<T>(
+    val initial: T,
     val name: String,
     val transform: Transform<T>?,
     val validators: List<Validators>

--- a/form-builder/src/main/java/com/dsc/form_builder/ChoiceState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/ChoiceState.kt
@@ -5,6 +5,8 @@ package com.dsc.form_builder
  * In this case the user is limited to a single choice.
  * Only [Validators.Required] and [Validators.Custom] are supported for this class.
  *
+ * @param initial the initial value/state of the field. By default this is an empty string so none of the choices are selected.
+ *
  * @param name the name of the state used to get an instance of the state from the form builder.
  * using the [FormBuilder.getState] method.
  *
@@ -17,9 +19,10 @@ package com.dsc.form_builder
  */
 class ChoiceState(
     name: String,
+    initial: String = "",
     validators: List<Validators>,
     transform: Transform<String>? = null,
-) : TextFieldState(name = name, validators = validators, transform = transform) {
+) : TextFieldState(initial = initial, name = name, validators = validators, transform = transform) {
 
     /**
      * This function all [validators] passed in to th state class against the state's value.

--- a/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
@@ -6,6 +6,8 @@ import androidx.compose.runtime.mutableStateListOf
  * SelectState is a state class that holds the selected values from a selection such as checkboxes.
  * In this case the user can make several selections and the state will hold the selected values.
  *
+ * @param initial the initial value/state of the field. By default it is an empty list so no values are selected.
+ *
  * @param name the name of the state used to get an instance of the state from the form builder.
  * using the [FormBuilder.getState] method.
  *
@@ -18,16 +20,17 @@ import androidx.compose.runtime.mutableStateListOf
  */
 class SelectState(
     name: String,
+    initial: MutableList<String> = mutableListOf(),
     transform: Transform<MutableList<String>>? = null,
     validators: List<Validators> = listOf()
-) : BaseState<MutableList<String>>(name = name, transform = transform, validators) {
+) : BaseState<MutableList<String>>(initial = initial, name = name, transform = transform, validators) {
 
     /**
      * The variable that holds the selected values of the state.
      * This variable should only be updated via the [select] and [unselect] method.
      *
      */
-    override var value: MutableList<String> = mutableStateListOf()
+    override var value: MutableList<String> = initial
 
     /**
      * This function adds the selected item to the state. It also hides the error message.

--- a/form-builder/src/main/java/com/dsc/form_builder/TextFieldState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/TextFieldState.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.*
  * It also helps keep track of form field input changes and pass updates to the onValueChange callback.
  *
  * @param name The name of the field used to access the state when required in the form
+ * @param initial The initial value/state of the field. By default it is an empty string.
  * @param transform The function used to change the [String] data type on the text field to a suitable type e.g [String] to [Int].
  * @param validators This is the list of [Validators] that are used to validate the field state. By default the field states will have an empty list. You can override this and provide your own list of validators.
  *
@@ -19,15 +20,16 @@ import androidx.compose.runtime.*
  */
 open class TextFieldState(
     name: String,
+    initial: String = "",
     transform: Transform<String>? = null,
     validators: List<Validators> = listOf(),
-) : BaseState<String>(name, transform, validators) {
+) : BaseState<String>(initial = initial, name = name, transform = transform, validators = validators) {
 
     /**
      * A mutable value holder that reads to the initial parameter during the execution of a [Composable]
      * function, the current [RecomposeScope] will be subscribed to changes of this value.
      */
-    override var value: String by mutableStateOf("")
+    override var value: String by mutableStateOf(initial)
 
     /**
      * A function to update the [RecomposeScope] with the latest [value].

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 17 16:08:59 EAT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
With the recent update, setting an initial value by using the `change` method will make the input disabled. This is because every time the UI is drawn or updated, the `change` method you specified is called therefore the value never changes.

This fix implements the `initial` parameter for each of the available states so other developers can implement them.