### PR TITLE
TextFieldState Unit tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.6.10"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
-        kotlin_version = '1.6.10'
-        compose_version = '1.1.0'
+        kotlin_version = '1.7.0'
+        compose_version = '1.2.0'
     }
     repositories {
         google()

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -4,12 +4,12 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 32
 
     defaultConfig {
         applicationId "com.dsc.formbuilder"
         minSdk 21
-        targetSdk 31
+        targetSdk 32
         versionCode 1
         versionName "1.0"
 
@@ -31,7 +31,6 @@ android {
     }
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
     buildFeatures {
         compose true
@@ -50,11 +49,11 @@ dependencies {
 
     implementation project(':form-builder')
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    implementation 'androidx.core:core-ktx:1.8.0'
+    implementation 'androidx.appcompat:appcompat:1.5.0'
+    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.5.1'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/form-builder/build.gradle
+++ b/form-builder/build.gradle
@@ -30,7 +30,6 @@ android {
 
     kotlinOptions {
         jvmTarget = '1.8'
-        useIR = true
     }
 
     testOptions {

--- a/form-builder/build.gradle
+++ b/form-builder/build.gradle
@@ -22,38 +22,46 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = '1.8'
         useIR = true
     }
+
+    testOptions {
+        unitTests.all {
+            useJUnitPlatform()
+        }
+    }
+
     buildFeatures {
         compose true
     }
+
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
     }
 }
 
 dependencies {
+    // Testing
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:4.0.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation 'com.google.android.material:material:1.5.0'
-
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-
-    // compose
-    implementation 'androidx.activity:activity-compose:1.4.0'
+    // Compose
+    implementation 'androidx.activity:activity-compose:1.5.1'
 
     // Kotlin reflection
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 }
+
+
 
 afterEvaluate {
     publishing {

--- a/form-builder/src/main/AndroidManifest.xml
+++ b/form-builder/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.dsc.form_builder">
+<manifest package="com.dsc.form_builder">
 
 </manifest>

--- a/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
@@ -1,6 +1,5 @@
 package com.dsc.form_builder
 
-import android.util.Log
 import androidx.compose.runtime.*
 
 /**
@@ -10,7 +9,7 @@ import androidx.compose.runtime.*
  * @param initial the initial value/state of the field. By default it is an empty list so no values are selected.
  *
  * @param name the name of the state used to get an instance of the state from the form builder.
- * using the [FormBuilder.getState] method.
+ * using the [FormState.getState] method.
  *
  * @param transform the transformation function used to transform the values of the state to a desired type.
  * This function will be applied to the value before it is returned.

--- a/form-builder/src/main/java/com/dsc/form_builder/TextFieldState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/TextFieldState.kt
@@ -1,6 +1,5 @@
 package com.dsc.form_builder
 
-import android.util.Patterns
 import androidx.compose.runtime.*
 
 /**
@@ -36,9 +35,9 @@ open class TextFieldState(
      * Once the [value] changes it clears errors by the help of
      * [BaseState.hideError]
      */
-    fun change(value: String) {
+    fun change(update: String) {
         hideError()
-        this.value = value
+        this.value = update
     }
 
     /**
@@ -83,8 +82,9 @@ open class TextFieldState(
      *The implementation makes use of the [android.util.Patterns] class to match the email address.
      *@param message the error message passed to [showError] to display if the value is not a valid email address. By default we use the [EMAIL_MESSAGE] constant.
      */
-    private fun validateEmail(message: String): Boolean {
-        val valid = Patterns.EMAIL_ADDRESS.matcher(value).matches()
+    internal fun validateEmail(message: String): Boolean {
+        val emailRegex = "^[A-Za-z](.*)([@])(.+)(\\.)(.+)"
+        val valid = emailRegex.toRegex().matches(value)
         if (!valid) showError(message)
         return valid
     }
@@ -106,7 +106,7 @@ open class TextFieldState(
      * @param limit the maximum characters that [value] can hold.
      * @param message the error message passed to [showError] to display if the characters are greater than the limit.
      */
-    private fun validateMaxChars(limit: Int, message: String): Boolean {
+    internal fun validateMaxChars(limit: Int, message: String): Boolean {
         val valid = value.length <= limit
         if (!valid) showError(message)
         return valid
@@ -118,7 +118,7 @@ open class TextFieldState(
      * @param limit the least number of characters that [value] can hold.
      * @param message the error message passed to [showError] to display if the characters are lesser than the limit.
      */
-    private fun validateMinChars(limit: Int, message: String): Boolean {
+    internal fun validateMinChars(limit: Int, message: String): Boolean {
         val valid = value.length >= limit
         if (!valid) showError(message)
         return valid
@@ -131,7 +131,7 @@ open class TextFieldState(
      * @param limit the least numeric value that [value] can hold.
      * @param message the error message passed to [showError] to display if the numeric value is lesser than the limit.
      */
-    private fun validateMinValue(limit: Int, message: String): Boolean {
+    internal fun validateMinValue(limit: Int, message: String): Boolean {
         val valid = value.isNumeric() && value.toDouble() >= limit
         if (!valid) showError(message)
         return valid
@@ -143,7 +143,7 @@ open class TextFieldState(
      * @param limit the greatest numeric value that [value] can hold.
      * @param message the error message passed to [showError] to display if the numeric value is greater than the limit.
      */
-    private fun validateMaxValue(limit: Int, message: String): Boolean {
+    internal fun validateMaxValue(limit: Int, message: String): Boolean {
         val valid = value.isNumeric() && value.toDouble() <= limit
         if (!valid) showError(message)
         return valid

--- a/form-builder/src/main/java/com/dsc/form_builder/Validators.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/Validators.kt
@@ -6,7 +6,7 @@ private const val REQUIRED_MESSAGE = "this field is required"
 /**
  *
  * These are the types of validators available in the form builder library.
- * They all have the [message] parameter to allow the developer to set their own custom error message.
+ * They all have the _message_ parameter to allow the developer to set their own custom error message.
  *
  * @author [Linus Muema](https://github.com/linusmuema)
  * @created 05/04/2022 - 10:00 AM

--- a/form-builder/src/test/java/com/dsc/form_builder/TextFieldProviders.kt
+++ b/form-builder/src/test/java/com/dsc/form_builder/TextFieldProviders.kt
@@ -1,0 +1,48 @@
+package com.dsc.form_builder
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+object EmailArgumentsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of("test@", false),
+        Arguments.of("test@mail", false),
+        Arguments.of("test@mail.com", true),
+    )
+}
+
+object MinCharsArgumentsProvider: ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of("test", 2, true),
+        Arguments.of("test", 4, true),
+        Arguments.of("test", 6, false),
+    )
+}
+
+object MaxCharsArgumentsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of("test", 6, true),
+        Arguments.of("test", 4, true),
+        Arguments.of("test", 2, false),
+    )
+}
+
+object MinValueArgumentsProvider: ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of("20", 15, true),
+        Arguments.of("20", 20, true),
+        Arguments.of("20", 25, false),
+        Arguments.of("test", 25, false),
+    )
+}
+
+object MaxValueArgumentsProvider : ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of("20", 25, true),
+        Arguments.of("20", 20, true),
+        Arguments.of("20", 15, false),
+        Arguments.of("test", 15, false),
+    )
+}

--- a/form-builder/src/test/java/com/dsc/form_builder/TextFieldStateTest.kt
+++ b/form-builder/src/test/java/com/dsc/form_builder/TextFieldStateTest.kt
@@ -1,0 +1,101 @@
+package com.dsc.form_builder
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+
+internal class TextFieldStateTest {
+
+    @Nested
+    inner class DescribingStateChanges {
+        private val classToTest: TextFieldState = TextFieldState(name = "")
+
+        @Test
+        fun `errors should be hidden`() {
+            // Simulate an existing validation error
+            classToTest.hasError = true
+            classToTest.errorMessage = "error message"
+
+            val newValue = "new value"      // Given a TextFieldState and a new value
+            classToTest.change(newValue)    // When change is called
+
+            assert(!classToTest.hasError)
+            assert(classToTest.errorMessage.isEmpty())
+        }
+
+        @Test
+        fun `state should be updated`() {
+            val newValue = "new value"      // Given a TextFieldState and a new value
+            classToTest.change(newValue)    // When change is called
+
+            assert(classToTest.value == "new value")
+        }
+
+    }
+
+    @Nested
+    inner class DescribingValidation {
+
+        private val classToTest: TextFieldState = TextFieldState(name = "")
+
+        @Test
+        fun `Validators_Required works correctly`() {
+
+            // Verify when state hasn't changed
+            val firstActual = classToTest.validateRequired("")
+            assert(!firstActual)
+
+            // Verify when state has changed
+            classToTest.change("non-empty")
+            val secondActual = classToTest.validateRequired("")
+            assert(secondActual)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(EmailArgumentsProvider::class)
+        fun `Validators_Email works correctly`(email: String, expected: Boolean) {
+            classToTest.change(email)
+
+            val actual = classToTest.validateEmail("expected validation: $expected")
+            assert(actual == expected)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MinCharsArgumentsProvider::class)
+        fun `Validators_MinChars works correctly`(value: String, limit: Int, expected: Boolean) {
+            classToTest.change(value)
+
+            val actual = classToTest.validateMinChars(limit, "expected validation: $expected")
+            assert(actual == expected)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MaxCharsArgumentsProvider::class)
+        fun `Validators_MaxChars works correctly`(value: String, limit: Int, expected: Boolean) {
+            classToTest.change(value)
+
+            val actual = classToTest.validateMaxChars(limit, "expected validation: $expected")
+            assert(actual == expected)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MinValueArgumentsProvider::class)
+        fun `Validators_MinValue works correctly`(value: String, limit: Int, expected: Boolean) {
+            classToTest.change(value)
+
+            val actual = classToTest.validateMinValue(limit, "expected validation: $expected")
+            assert(actual == expected)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MaxValueArgumentsProvider::class)
+        fun `Validators_MaxValue works correctly`(value: String, limit: Int, expected: Boolean) {
+            classToTest.change(value)
+
+            val actual = classToTest.validateMaxValue(limit, "expected validation: $expected")
+            assert(actual == expected)
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,7 +3,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        jcenter() // Warning: this repository is going to shut down soon
     }
 }
 rootProject.name = "Form Builder"


### PR DESCRIPTION
Added unit tests to describe the basic behaviour of the class. The tests also check on the validators and the corresponding methods. 

I am using JUnit5 for nested tests (grouping related tests) and parametized tests. With parametized tests we can provide various states and the expected validation response. 

> There is still an issue with mocks when it comes property delegation (for the `errorMessage` and `hasError`) variables in the `BaseState` so for the tests I used a fake of the TextFieldState 🫠