### PR TITLE
Bugfix: GetData Defaults

### DIFF
--- a/example/src/main/java/com/dsc/formbuilder/screens/survey/SurveyViewmodel.kt
+++ b/example/src/main/java/com/dsc/formbuilder/screens/survey/SurveyViewmodel.kt
@@ -1,10 +1,12 @@
 package com.dsc.formbuilder.screens.survey
 
+import android.util.Log
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import com.dsc.form_builder.*
+import com.dsc.formbuilder.screens.survey.components.SurveyModel
 
 class SurveyViewmodel : ViewModel() {
 
@@ -47,7 +49,7 @@ class SurveyViewmodel : ViewModel() {
                     Validators.Required(
                         message = "Select at least one platform"
                     )
-                )
+                ),
             ),
             SelectState(
                 name = "language",
@@ -101,14 +103,25 @@ class SurveyViewmodel : ViewModel() {
         if (!formState.validate()){
             val position = formState.fields.indexOfFirst { it.hasError }
             _screen.value = pages.indexOfFirst { it.contains(position) }
-        } else _finish.value = true
+        } else {
+            logData()
+            _finish.value = true
+        }
     }
 
     fun validateScreen(screen: Int) {
         val fields: List<BaseState<*>> = formState.fields.chunked(3)[screen]
         if (fields.map { it.validate() }.all { it }){ // map is used so we can execute validate() on all fields in that screen
-            if (screen == 2) _finish.value = true
+            if (screen == 2){
+                logData()
+                _finish.value = true
+            }
             _screen.value += 1
         }
+    }
+
+    private fun logData() {
+        val data = formState.getData(SurveyModel::class)
+        Log.d("SurveyLog", "form data is $data")
     }
 }

--- a/example/src/main/java/com/dsc/formbuilder/screens/survey/components/SurveyModel.kt
+++ b/example/src/main/java/com/dsc/formbuilder/screens/survey/components/SurveyModel.kt
@@ -1,0 +1,18 @@
+package com.dsc.formbuilder.screens.survey.components
+
+data class SurveyModel(
+    // First page
+    val email: String,
+    val number: String,
+    val username: String,
+
+    // Second page
+    val ide: List<String>,
+    val platform: List<String>,
+    val language: List<String>,
+
+    // Third page
+    val os: String,
+    val gender: String,
+    val experience: String,
+)

--- a/form-builder/src/main/java/com/dsc/form_builder/FormState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/FormState.kt
@@ -33,15 +33,17 @@ open class FormState<T : BaseState<*>>(val fields: List<T>) {
         val args: MutableMap<KParameter, Any?> = mutableMapOf()
         constructor.parameters.associateWith {
             val value = map[it.name]
-            checkNotNull(value) {
-                """
-                    A non-null value (${it.name}) in your class doesn't have a matching field in the form data. 
-                    This will throw a NullPointerException when creating $dataClass. To solve this, you can:
-                    1. Make the value nullable in your data class
-                    2. Provide a default value for the parameter
-                """.trimIndent()
+            if (!it.isOptional) {
+                checkNotNull(value) {
+                    """
+                        A non-null value (${it.name}) in your class doesn't have a matching field in the form data. 
+                        This will throw a NullPointerException when creating $dataClass. To solve this, you can:
+                        1. Make the value nullable in your data class
+                        2. Provide a default value for the parameter
+                    """.trimIndent()
+                }
+                args[it] = value
             }
-            if (!it.isOptional) args[it] = value
         }
         return constructor.callBy(args)
     }

--- a/form-builder/src/main/java/com/dsc/form_builder/FormState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/FormState.kt
@@ -30,7 +30,19 @@ open class FormState<T : BaseState<*>>(val fields: List<T>) {
     fun <T : Any> getData(dataClass: KClass<T>): T {
         val map = fields.associate { it.name to it.getData() }
         val constructor = dataClass.constructors.last()
-        val args: Map<KParameter, Any?> = constructor.parameters.associateWith { map[it.name] }
+        val args: MutableMap<KParameter, Any?> = mutableMapOf()
+        constructor.parameters.associateWith {
+            val value = map[it.name]
+            checkNotNull(value) {
+                """
+                    A non-null value (${it.name}) in your class doesn't have a matching field in the form data. 
+                    This will throw a NullPointerException when creating $dataClass. To solve this, you can:
+                    1. Make the value nullable in your data class
+                    2. Provide a default value for the parameter
+                """.trimIndent()
+            }
+            if (!it.isOptional) args[it] = value
+        }
         return constructor.callBy(args)
     }
 }

--- a/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
+++ b/form-builder/src/main/java/com/dsc/form_builder/SelectState.kt
@@ -75,7 +75,7 @@ class SelectState(
      * @param message the error message to be displayed if the state's value does not meet the validation criteria.
      * @return true if the state's value is more than the [limit] passed in to the [Validators.Min] class.
      */
-    private fun validateMin(limit: Int, message: String): Boolean {
+    internal fun validateMin(limit: Int, message: String): Boolean {
         val valid = value.size >= limit
         if (!valid) showError(message)
         return valid
@@ -88,7 +88,7 @@ class SelectState(
      * @param message the error message to be displayed if the state's value does not meet the validation criteria.
      * @return true if the state's value is less than the [limit] passed in to the [Validators.Max] class.
      */
-    private fun validateMax(limit: Int, message: String): Boolean {
+    internal fun validateMax(limit: Int, message: String): Boolean {
         val valid = value.size <= limit
         if (!valid) showError(message)
         return valid
@@ -99,7 +99,7 @@ class SelectState(
      * @param message the error message to be displayed if the state's value does not meet the validation criteria.
      * @return true if the state's value is not empty.
      */
-    private fun validateRequired(message: String): Boolean {
+    internal fun validateRequired(message: String): Boolean {
         val valid = value.isNotEmpty()
         if (!valid) showError(message)
         return valid

--- a/form-builder/src/test/java/com/dsc/form_builder/SelectStateProviders.kt
+++ b/form-builder/src/test/java/com/dsc/form_builder/SelectStateProviders.kt
@@ -1,0 +1,22 @@
+package com.dsc.form_builder
+
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.ArgumentsProvider
+import java.util.stream.Stream
+
+object MinArgumentsProvider: ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of(mutableListOf("item 1"), 2, false),
+        Arguments.of(mutableListOf("item 1", "item 2"), 2, true),
+        Arguments.of(mutableListOf("item 1", "item 2", "item 3"), 2, true),
+    )
+}
+
+object MaxArgumentsProvider: ArgumentsProvider {
+    override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> = Stream.of(
+        Arguments.of(mutableListOf("item 1"), 2, true),
+        Arguments.of(mutableListOf("item 1", "item 2"), 2, true),
+        Arguments.of(mutableListOf("item 1", "item 2", "item 3"), 2, false),
+    )
+}

--- a/form-builder/src/test/java/com/dsc/form_builder/SelectStateTest.kt
+++ b/form-builder/src/test/java/com/dsc/form_builder/SelectStateTest.kt
@@ -1,0 +1,72 @@
+package com.dsc.form_builder
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+
+internal class SelectStateTest {
+
+    @Nested
+    inner class DescribingStateChanges {
+        private val classToTest: SelectState = SelectState(name = "test")
+
+        @Test
+        fun `errors should be hidden`() {
+            // Simulate an existing validation error
+            classToTest.hasError = true
+            classToTest.errorMessage = "error message"
+
+            val newValue = "new item"      // Given a TextFieldState and a new value
+            classToTest.select(newValue)    // When change is called
+
+            assert(!classToTest.hasError)
+            assert(classToTest.errorMessage.isEmpty())
+        }
+
+        @Test
+        fun `state should be updated`() {
+            val item = "new item"      // Given a TextFieldState and a new value
+            classToTest.select(item)    // When change is called
+
+            assert(classToTest.value.contains(item)) // Then state should have the item
+
+            classToTest.unselect(item)
+            assert(!classToTest.value.contains(item)) // Then state should NOT have the item
+        }
+    }
+
+    @Nested
+    inner class DescribingValidation {
+        private val classToTest: SelectState = SelectState(name = "test")
+
+        @Test
+        fun `Validators_Required works correctly`(){
+            // When state is empty
+            val firstValidation = classToTest.validateRequired("should fail")
+            assert(!firstValidation)
+
+            classToTest.select("item")
+            val secondValidation = classToTest.validateRequired("should pass")
+            assert(secondValidation)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MinArgumentsProvider::class)
+        fun `Validators_Min works correctly`(value: MutableList<String>, min: Int, expected: Boolean){
+            classToTest.value = value // set the field state
+
+            val actual = classToTest.validateMin(min, "expected validation: $expected")
+            assert(actual == expected)
+        }
+
+        @ParameterizedTest
+        @ArgumentsSource(MaxArgumentsProvider::class)
+        fun `Validators_Max works correctly`(value: MutableList<String>, max: Int, expected: Boolean){
+            classToTest.value = value // set the field state
+
+            val actual = classToTest.validateMax(max, "expected validation: $expected")
+            assert(actual == expected)
+        }
+    }
+}


### PR DESCRIPTION
Issue was reported via email. When a data class has default parameters or parameters not available in the form, the application will crash once the `getData` function is called. To solve this:
1. Check if the parameter `isOptional`. If true, then we know it has a default parameter specified in the data class.
2. If not true, we check if the form data has that field. If it doesn't exist, we throw an IllegalStateException with a descriptive error message.

> Also, I added tests for `SelectState`